### PR TITLE
PHP 8.0 with Nova 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 8.1
+  - 8.0
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A field that make your resources orderable using [the laravel nestedset package]
 
 ## Requirements
 
-* PHP >= 8.1
-* Laravel Nova >= 4.0
+* PHP >= 8.0
+* Laravel Nova >= 3.0
 * Laravel Framework >= 9.0
 
-> **NOTE**: These instructions are for Laravel >= 9.0 and Laravel Nova 4.0. If you are using prior version, please
+> **NOTE**: These instructions are for Laravel >= 9.0 and Laravel Nova 3.0. If you are using prior version, please
 > see the [previous version's docs](https://github.com/novius/laravel-nova-order-nestedset-field/tree/2.x).
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.0",
     "illuminate/support": "^9.0",
     "kalnoy/nestedset": "^6.0.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.8.0"
+    "friendsofphp/php-cs-fixer": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hi,
This sets the PHP 8.0 to be same used in Laravel 9.
This closes #12

I set the base branch of this PR to master, but I should be on a 3.x branch. Could you create one please?
Karel