### PR TITLE
PHP 8.0 with Nova 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 8.1
+  - 8.0
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A field that make your resources orderable using [the laravel nestedset package]
 
 ## Requirements
 
-* PHP >= 8.1
+* PHP >= 8.0
 * Laravel Nova >= 4.0
 
 > **NOTE**: These instructions are for Laravel Nova 4.0. If you are using prior version, please

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.0",
     "laravel/nova": "^4.0",
     "kalnoy/nestedset": "^6.0.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.8.0"
+    "friendsofphp/php-cs-fixer": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hi,
This sets the PHP minimum to 8.0 to match Laravel 9.
This closes https://github.com/novius/laravel-nova-order-nestedset-field/issues/12
Karel